### PR TITLE
Add regex replace to change relative links into fully qualified urls

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -66,6 +66,8 @@ module.exports = {
 
         let content = res.data;
 
+        content = content.replace(/\](?!.*(http|#))\(/g,`](https://github.com/laravel-notification-channels/${channel.slug}/blob/master/`)
+
         content = `<ChannelHeader slug="${channel.slug}" :maintainers='${JSON.stringify(channel.maintainers)}'></ChannelHeader>\n` + content
 
         if (channel.deprecated) {


### PR DESCRIPTION
My proposed fix for relative links issue to close #45 

The regex is designed to look for any markdown link syntax like `](` that isn't followed by http or #. This seems to work tested locally, but please feel free to propose changes if there's another link case I've missed, or if a none regex based solution is prefered.

